### PR TITLE
build T40 only, with easter eggs enabled

### DIFF
--- a/software/platformio.ini
+++ b/software/platformio.ini
@@ -11,14 +11,7 @@
 [platformio]
 src_dir = src
 default_envs =
-    prod
-    prod_vor
     T40
-    T41
-    nlm_left
-    nlm_right
-    nlm_hoc_T40
-    nlm_cardoc_T40
 
 [env]
 framework = arduino
@@ -61,7 +54,7 @@ build_flags =
 [env:T4]
 build_flags =
   ${env.build_flags}
-;  -DPEWPEWPEW
+  -DPEWPEWPEW
   -DDRUMMAP_GRIDS2
   -DENABLE_APP_CALIBR8OR
   -DENABLE_APP_SCENES


### PR DESCRIPTION
I made this edit right in the browser on the Github website, as an example of how to customize the firmware in your fork.

After merging the change, the "PlatformIO CI" workflow will produce an artifact file containing the binary HEX.